### PR TITLE
fix options to `nodepool add` command

### DIFF
--- a/articles/aks/gpu-multi-instance.md
+++ b/articles/aks/gpu-multi-instance.md
@@ -60,9 +60,9 @@ If you're using command line, use the `az aks nodepool add` command to create th
 
 az aks nodepool add \
     --name mignode \
-    --resourcegroup myresourcegroup \
+    --resource-group myresourcegroup \
     --cluster-name migcluster \
-    --node-size Standard_ND96asr_v4 \
+    --node-vm-size Standard_ND96asr_v4 \
     --gpu-instance-profile MIG1g
 ```
 


### PR DESCRIPTION
fix two errors in the `az aks nodepool add` example:
`resourcegroup` -> `resource-group`
`node-size` -> `node-vm-size`